### PR TITLE
Post v2，Miyabi v2対応

### DIFF
--- a/frontend/src/app/(main)/post/[postId]/actions/fetchOnePost.ts
+++ b/frontend/src/app/(main)/post/[postId]/actions/fetchOnePost.ts
@@ -10,15 +10,15 @@ const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
  * @async
  * @function fetchOnePost
  * @param {Object} params - 投稿データ取得のためのパラメータオブジェクト
- * @param {string} params.iconUrl - ユーザのアイコン画像URL
+ * @param {string} params.userId - ユーザのID
  * @param {string} params.postId - 取得する投稿のID（オフセット）
  * @returns {Promise<PostTypes[]>} 投稿データを返すPromise．投稿が存在しない場合はnullを返す．
  */
 export const fetchOnePost = async ({
-  iconUrl,
+  userId,
   postId,
 }: {
-  iconUrl?: string;
+  userId?: string;
   postId?: string;
 }): Promise<PostTypes | null> => {
   try {
@@ -28,8 +28,8 @@ export const fetchOnePost = async ({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        my_icon: iconUrl,
-        post_id: postId,
+        id: postId,
+        viewerId: userId,
       }),
     });
 
@@ -41,19 +41,19 @@ export const fetchOnePost = async ({
 
     const json = await res.json();
     const post: PostTypes = {
-      id: json.id,
-      tanka: json.tanka,
-      original: json.original,
-      imageUrl: json.image_path ?? '',
-      date: new Date(json.created_at),
+      id: json.post.id,
+      tanka: json.post.tanka,
+      original: json.post.original,
+      imageUrl: json.post.image_path ?? '',
+      date: new Date(json.post.created_at),
       user: {
-        name: json.user_name,
-        iconUrl: json.user_icon,
-        userId: json.user_id,
+        name: json.post.user_name,
+        iconUrl: json.post.user_icon,
+        userId: json.post.user_id,
       },
-      miyabiCount: json.miyabi_count,
-      miyabiIsClicked: json.is_miyabi,
-      rank: json.rank,
+      miyabiCount: json.post.miyabi_count,
+      miyabiIsClicked: json.post.is_miyabi,
+      rank: json.post.rank,
     };
     return post;
   } catch (error) {

--- a/frontend/src/app/(main)/post/[postId]/page.tsx
+++ b/frontend/src/app/(main)/post/[postId]/page.tsx
@@ -12,8 +12,8 @@ export const generateMetadata = async (context: { params: Promise<{ postId: stri
   const params = await context.params;
 
   const post = await fetchOnePost({
+    userId: '',
     postId: params.postId,
-    iconUrl: '',
   });
 
   if (!post) return { title: '投稿が見つかりません' };
@@ -35,8 +35,8 @@ const Page = async (context: { params: Promise<{ postId: string }> }) => {
   const session = await auth();
 
   const post = await fetchOnePost({
+    userId: session?.user_id ?? '',
     postId: params.postId,
-    iconUrl: session?.user?.image ?? '',
   });
 
   if (!post) notFound();

--- a/frontend/src/app/(main)/timeline/actions/countMiyabi.ts
+++ b/frontend/src/app/(main)/timeline/actions/countMiyabi.ts
@@ -8,10 +8,10 @@ const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
  * @async
  * @function addMiyabi
  * @param {Object} params - 雅追加のためのパラメータオブジェクト
- * @param {string} params.iconUrl - ユーザのアイコン画像URL
+ * @param {string} params.userId - ユーザのID
  * @param {string} params.postId - 雅する投稿のID
  */
-export const addMiyabi = async ({ iconUrl, postId }: { iconUrl: string; postId: string }) => {
+export const addMiyabi = async ({ userId, postId }: { userId: string; postId: string }) => {
   try {
     const res = await fetch(`${backendUrl}/miyabi`, {
       method: 'POST',
@@ -19,8 +19,8 @@ export const addMiyabi = async ({ iconUrl, postId }: { iconUrl: string; postId: 
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
+        user_id: userId,
         post_id: postId,
-        my_icon: iconUrl,
       }),
     });
 
@@ -38,10 +38,10 @@ export const addMiyabi = async ({ iconUrl, postId }: { iconUrl: string; postId: 
  * @async
  * @function removeMiyabi
  * @param {Object} params - 雅追加のためのパラメータオブジェクト
- * @param {string} params.iconUrl - ユーザのアイコン画像URL
+ * @param {string} params.userId - ユーザのID
  * @param {string} params.postId - 雅する投稿のID
  */
-export const removeMiyabi = async ({ iconUrl, postId }: { iconUrl: string; postId: string }) => {
+export const removeMiyabi = async ({ userId, postId }: { userId: string; postId: string }) => {
   try {
     const res = await fetch(`${backendUrl}/miyabi`, {
       method: 'DELETE',
@@ -50,7 +50,7 @@ export const removeMiyabi = async ({ iconUrl, postId }: { iconUrl: string; postI
       },
       body: JSON.stringify({
         post_id: postId,
-        my_icon: iconUrl,
+        user_id: userId,
       }),
     });
 

--- a/frontend/src/app/(main)/timeline/actions/deletePost.ts
+++ b/frontend/src/app/(main)/timeline/actions/deletePost.ts
@@ -8,15 +8,15 @@ const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
  * @async
  * @function deletePost
  * @param {Object} params - 投稿データ取得のためのパラメータオブジェクト
- * @param {string} params.iconUrl - ユーザのアイコン画像URL
+ * @param {string} params.userId - ユーザのID
  * @param {string} params.postId - 削除する投稿のID
  * @returns {Promise<boolean>} 結果を返すPromise．
  */
 const deletePost = async ({
-  iconUrl,
+  userId,
   postId,
 }: {
-  iconUrl: string;
+  userId: string;
   postId: string;
 }): Promise<boolean> => {
   try {
@@ -26,8 +26,8 @@ const deletePost = async ({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        user_icon: iconUrl,
         post_id: postId,
+        user_id: userId,
       }),
     });
 

--- a/frontend/src/app/(main)/timeline/actions/fetchPosts.ts
+++ b/frontend/src/app/(main)/timeline/actions/fetchPosts.ts
@@ -26,21 +26,21 @@ interface PostResponse {
  * @function fetchPosts
  * @param {Object} params - 投稿データ取得のためのパラメータオブジェクト
  * @param {number} params.limit - 取得する投稿の最大件数
- * @param {string} params.iconUrl - ユーザのアイコン画像URL
- * @param {string} params.offsetId - 取得を開始する投稿のID（オフセット）
- * @param {string} params.targetUserId - 取得する対象のユーザID
+ * @param {string} params.cursor - 取得を開始する投稿のID（オフセット）
+ * @param {string} params.filterByUserId - 取得する対象のユーザID
+ * @param {string} params.userId - 閲覧ユーザのID
  * @returns {Promise<PostTypes[]>} 投稿データの配列を返すPromise．投稿が存在しない場合は空配列を返す．
  */
 export const fetchPosts = async ({
   limit,
-  iconUrl,
-  offsetId,
-  targetUserId,
+  cursor,
+  filterByUserId,
+  userId,
 }: {
   limit: number;
-  iconUrl?: string;
-  offsetId?: string;
-  targetUserId?: string;
+  cursor?: string;
+  filterByUserId?: string;
+  userId?: string;
 }): Promise<PostTypes[] | []> => {
   try {
     const res = await fetch(`${backendUrl}/timeline`, {
@@ -50,9 +50,9 @@ export const fetchPosts = async ({
       },
       body: JSON.stringify({
         limit: limit,
-        my_icon: iconUrl,
-        post_id: offsetId,
-        user_id: targetUserId,
+        cursor: cursor,
+        filterByUserId: filterByUserId,
+        viewerId: userId,
       }),
     });
 

--- a/frontend/src/app/yomu/page.tsx
+++ b/frontend/src/app/yomu/page.tsx
@@ -149,8 +149,7 @@ const SignedInPage = (): React.ReactNode => {
     const res = await postYomu({
       originalText: text,
       imageData: file?.file ?? null,
-      userName: session.data?.user?.name ?? '',
-      userIconPath: session.data?.user?.image ?? '',
+      userId: session.data?.user_id ?? '',
     });
 
     if (res.message !== '投稿に成功しました') {

--- a/frontend/src/app/yomu/postActions.ts
+++ b/frontend/src/app/yomu/postActions.ts
@@ -3,8 +3,7 @@
 interface PostData {
   originalText: string;
   imageData?: File | null;
-  userName: string;
-  userIconPath: string;
+  userId: string;
 }
 
 export interface PostResult {
@@ -27,8 +26,7 @@ export const postYomu = async (data: PostData): Promise<PostResult> => {
 
     const formData = new FormData();
     formData.append('original', data.originalText);
-    formData.append('user_name', data.userName);
-    formData.append('user_icon', data.userIconPath);
+    formData.append('user_id', data.userId);
 
     if (data.imageData) {
       formData.append('image', data.imageData);

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -181,7 +181,7 @@ const Post = ({ post, className, onDelete }: PostProps) => {
             onClick={async () => {
               if (isLoggedIn) {
                 setMiyabiCount((count) => ++count);
-                await addMiyabi({ postId: post.id, iconUrl: session.data?.user?.image ?? '' });
+                await addMiyabi({ userId: session.data?.user_id ?? '', postId: post.id });
               } else {
                 setLoginDialogOpen(true);
               }
@@ -189,7 +189,7 @@ const Post = ({ post, className, onDelete }: PostProps) => {
             onCancel={async () => {
               if (isLoggedIn) {
                 setMiyabiCount((count) => --count);
-                await removeMiyabi({ postId: post.id, iconUrl: session.data?.user?.image ?? '' });
+                await removeMiyabi({ userId: session.data?.user_id ?? '', postId: post.id });
               } else {
                 setLoginDialogOpen(true);
               }
@@ -211,8 +211,8 @@ const Post = ({ post, className, onDelete }: PostProps) => {
           console.log('はい');
           setDialogOpen(false);
           const result = await deletePost({
+            userId: session.data?.user_id ?? '',
             postId: post.id,
-            iconUrl: session.data?.user?.image ?? '',
           });
           if (!result) setDeleteFailedDialogOpen(true);
           else handleDelete();

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -51,8 +51,8 @@ const Post = ({ post, className, onDelete }: PostProps) => {
   const [toastOpen, setToastOpen] = useState(false);
   // 削除失敗ダイアログの表示状態
   const [deleteFailedDialogOpen, setDeleteFailedDialogOpen] = useState(false);
-  // ユーザアイコンURLが一致するなら自分の投稿
-  const isMyPost = useSession().data?.user?.image === post.user.iconUrl;
+  // ユーザIDが一致するなら自分の投稿
+  const isMyPost = useSession().data?.user_id === post.user.userId;
   // ドロップダウンメニューの要素
   const dropDownItems = [];
   // ドロップダウンメニューの投稿共有ボタン

--- a/frontend/src/components/SideMenu.tsx
+++ b/frontend/src/components/SideMenu.tsx
@@ -6,11 +6,10 @@ import { PiRankingLight } from 'react-icons/pi';
 import Image from 'next/image';
 import { signIn, signOut, useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Dialog from './Dialog';
 import LoginDialog from './LoginDialog';
 import { useRouter } from 'next/navigation';
-import fetchUserId from '@/app/(main)/timeline/actions/fetchUserId';
 
 // props の型定義
 interface SideMenuProps {
@@ -43,17 +42,7 @@ const SideMenu = ({ className, style, setIsOpen }: SideMenuProps) => {
   const [loginDialogOpen, setLoginDialogOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
-  const [userId, setUserId] = useState<string>('');
-
-  // アイコン画像URLからユーザIDをFetchする
-  useEffect(() => {
-    if (session.status !== 'authenticated') return;
-    const getUserId = async () => {
-      const data = await fetchUserId({ iconUrl: session.data?.user?.image ?? '' });
-      setUserId(data);
-    };
-    getUserId();
-  }, [session.status, session.data?.user?.image]);
+  const userId = isLoggedIn ? session.data?.user_id : undefined;
 
   return (
     <div className={`${className} z-10 w-40 space-y-3`} style={style}>
@@ -75,6 +64,7 @@ const SideMenu = ({ className, style, setIsOpen }: SideMenuProps) => {
         <div
           onClick={() => {
             if (setIsOpen) setIsOpen(false);
+            if (!userId) return;
             router.push(`${PATHNAME.PROFILE}/${userId}`);
           }}
           className={`flex items-center rounded-lg hover:cursor-pointer hover:bg-black/5 ${

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -57,9 +57,9 @@ const Timeline = ({ limit, max, targetUserId, mode = 'timeline', className }: Ti
     if (mode === 'timeline') {
       newPosts = await fetchPosts({
         limit: limit,
-        iconUrl: session.data?.user?.image ?? '',
-        offsetId: offsetIdRef.current,
-        targetUserId: targetUserId,
+        cursor: offsetIdRef.current,
+        filterByUserId: targetUserId,
+        userId: session.data?.user_id ?? '',
       });
     } else {
       newPosts = await fetchRanking({


### PR DESCRIPTION
現時点で実行できる従来の操作
- タイムラインの閲覧
- 雅をつける/はずす
- 共有された単一の短歌の閲覧
- 短歌の削除
- 短歌を詠む

まだできない従来の操作
- ランキング
- 自分/他ユーザのプロフィール閲覧