### PR TITLE
今度こそログインしている時だけ「推す」ボタンが出現

### DIFF
--- a/frontend/src/app/(main)/profile/[userId]/_components/ProfileBox.tsx
+++ b/frontend/src/app/(main)/profile/[userId]/_components/ProfileBox.tsx
@@ -124,7 +124,7 @@ const ProfileBox = ({ userId }: ProfileBoxProps) => {
               <p>総獲得雅数: {profile?.totalMiyabi ?? '取得中'}</p>
               <p>総詠歌数: {profile?.totalPost ? `${profile.totalPost}首` : '取得中'}</p>
             </div>
-            {session.data?.user_id !== userId && (
+            {session.status === 'authenticated' && session.data?.user_id !== userId && (
               <div className='mt-4 flex justify-center'>
                 <button
                   onClick={() => setIsFavorited(!isFavorited)}


### PR DESCRIPTION
frontendのProfileBoxにログイン判定を追加した。
ログインしている時、推すボタンは出てこなくなる。

なぜか短歌取得できなきなったタスケテ
