### PR TITLE
タイムラインを開くと不要なプロフィール取得が10回以上走る問題の修正

### DIFF
--- a/frontend/src/components/ReportDialog.tsx
+++ b/frontend/src/components/ReportDialog.tsx
@@ -43,6 +43,7 @@ const ReportDialog = ({ className, isOpen, setIsOpen, post }: ReportDialogProps)
 
   // ユーザIDからプロフィールをFetchする
   useEffect(() => {
+    if (!isOpen) return;
     const getProfile = async () => {
       if (!userId) return;
       const data = await fetchProfile({
@@ -52,7 +53,7 @@ const ReportDialog = ({ className, isOpen, setIsOpen, post }: ReportDialogProps)
       setProfile(data);
     };
     getProfile();
-  }, [userId, session.data?.user_id]);
+  }, [isOpen, userId, session.data?.user_id]);
 
   const handleReport = useCallback(async () => {
     try {


### PR DESCRIPTION
## 概要
タイムラインを開くと10回以上プロフィール取得が走っていたので修正．
通報ダイアログのコンポーネントで通報対象ユーザのプロフィールを取得しているが，これが通報ダイアログを開いていなくても呼ばれるため，タイムラインの全投稿に対して不必要に走っていた．
通報ダイアログを開いた時にだけ取得するように修正した．

## 備考
通報する際にプロフィール取得が完了するまで「通報」ボタンがDisabledになるが，通報内容を入力しないと通報できないため気にならないはず．