### PR TITLE
fix: 表示名が20文字を超えるGoogleアカウントでログインできない不具合を修正

### DIFF
--- a/frontend/src/auth/config.ts
+++ b/frontend/src/auth/config.ts
@@ -53,7 +53,8 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       if (trigger === 'signIn' && user && account) {
         try {
           const formData = new FormData();
-          formData.append('name', user.name || '歌人');
+          // バックエンドのname上限(20)で400になるため切り詰める
+          formData.append('name', (user.name || '歌人').slice(0, 20));
           formData.append('oauth_app', account.provider as ProviderType);
           if (user.email) {
             formData.append('connect_info', user.email);
@@ -61,10 +62,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
             throw new Error('ユーザのメールアドレスが取得できませんでした');
           }
 
-          // アイコンURLが存在する場合は追加する
-          if (user.image) {
-            formData.append('icon_url', user.image);
-          }
+          // 画像が無いアカウントでも400にしないよう既定アイコンを送る
+          const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+          formData.append('icon_url', user.image || `${baseUrl}/iconDefault.png`);
 
           const res = await fetch(`${process.env.BACKEND_URL}/user`, {
             method: 'POST',
@@ -72,7 +72,8 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           });
 
           if (!res.ok) {
-            console.error('ユーザの作成に失敗しました:', res);
+            const errorBody = await res.text();
+            console.error('ユーザの作成に失敗しました:', res.status, errorBody);
             throw new Error('ユーザの作成に失敗しました');
           }
 


### PR DESCRIPTION
## Summary
- 一部のGoogleアカウントだけログイン時に `/v2/user` が 400 を返し、`CallbackRouteError` でログインできなかった問題を修正しました。
- 原因はバックエンドの作成ロジックではなく、その手前の zod バリデーション（`name` 20文字上限・`icon_url` 必須）で弾かれていたこと。

## Changes

### ユーザ作成リクエストのペイロード是正（`frontend/src/auth/config.ts`）
- `name` を送信前に20文字へ切り詰め（`slice(0, 20)`）。Googleの表示名はフルネーム等で20文字を超えやすく、`name: z.string().max(20)` に違反して 400（`too_big`）になっていた。
- `icon_url` を常に送信するよう変更。画像が無いアカウントでは未送信で必須違反（400）になっていたため、`user.image` が無い場合は `${NEXT_PUBLIC_BASE_URL}/iconDefault.png` を既定値として送る。
- 作成失敗時のログを `Response` オブジェクトの丸出しから `res.status` ＋レスポンス本文へ変更し、再発時にどのフィールドで弾かれたか追えるようにした（エンドユーザーには非露出です）。

## 既存動作への影響
- **表示名20文字以内の既存ユーザ**: 影響なし。`slice(0, 20)` は変化を与えず、従来どおり `existing` で 200 ログイン。
- **表示名20文字超のユーザ**: これまでログイン不可（400）だったのが可能になる。ユーザ照合は `connect_info`＋`oauth_app` で行い `name` は使わないため、既存レコードとのマッチングには影響しない。切り詰めた名前が保存されるのは**新規作成時のみ**で、既存ユーザの登録名は上書きされない。
- **プロフィール画像の無いユーザ**: これまで作成不可（400）だったのが、既定アイコンで作成・ログインできる。
- バックエンドAPI・DBスキーマ・v1経路は変更なし。DBカラム `name VARCHAR(20)` とも整合。

## ロールバック方法
- フロントエンド1ファイルのみの変更のため、`git revert d45ba99`でロールバック可能
- DBへの不可逆な変更は含まないため、切り戻しに伴うデータ整合の懸念はなし