### PR TITLE
fix: 本番フロントコンテナが起動直後にクラッシュしログインできない障害を修正

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,10 +1,10 @@
-import type { NextConfig } from 'next';
+/** @type {import('next').NextConfig} */
 
 const cdnDomain = process.env.NEXT_PUBLIC_CDN_URL
   ? process.env.NEXT_PUBLIC_CDN_URL.split('//')[1]
   : '202502-test-bucket.s3.ap-northeast-1.amazonaws.com';
 
-const nextConfig: NextConfig = {
+const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: ['avatars.githubusercontent.com', cdnDomain, 'lh3.googleusercontent.com'],

--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+// ALBヘルスチェック用。認証やDBに依存せず稼働中サーバーの200応答だけを返す
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return new Response('ok', { status: 200 });
+}


### PR DESCRIPTION
## Summary
- ECS の frontend タスクが起動時に落ち、ALB ヘルスチェックに失敗して直前バージョンへロールバックされ続ける障害を解消する。
- 原因は `next start` が `next.config.ts` を読むのに `typescript` を要求するが、本番イメージ（`npm install --production`）に無く exit 1 でクラッシュしていたこと。設定を `.mjs` 化して実行時の TS 依存を断ち切る。あわせて依存しない `/api/health` を追加する。

## Changes

### Next 設定を実行時 TS 非依存にする（`frontend/next.config.mjs`）
- `next.config.ts` を `next.config.mjs`（素の ESM）にリネーム・変換。`NextConfig` 型注釈を JSDoc の `@type` に置き換え、中身（`reactStrictMode` / `images.domains` / `experimental.serverActions`）は不変。
- これにより Node がネイティブに設定を読み込み、`next start` 時の `typescript` 要求（起動時の 4 分自動インストール→`Cannot find module 'typescript'`→exit 1）が発生しなくなる。

### ヘルスチェック用エンドポイントを追加（`frontend/src/app/api/health/route.ts`）
- 認証・DB・環境変数に依存せず `200 'ok'` を返す `GET` を新設。`dynamic = 'force-dynamic'` で稼働中サーバーの応答であることを保証。
- ALB のヘルス対象を重い `/`（フォント取得・`SessionProvider` 込みのクライアントアプリ）から切り離し、死活監視を堅牢化する意図。
