### PR TITLE
Test/service behavior baseline

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^20.11.17",
         "tsx": "^4.7.1",
         "typescript": "^7.0.2",
+        "vitest": "^4.1.10",
         "wrangler": "^4.118.0"
       }
     },
@@ -1008,10 +1009,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2081,6 +2105,38 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -2173,6 +2229,278 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -2911,6 +3239,49 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.17.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.19.tgz",
@@ -3265,6 +3636,92 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3272,6 +3729,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/aws-ssl-profiles": {
@@ -3330,6 +3797,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -3370,6 +3847,13 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -3458,6 +3942,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
@@ -3497,6 +3988,26 @@
         "@esbuild/win32-x64": "0.23.1"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3523,6 +4034,24 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-blob": {
@@ -3732,6 +4261,267 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.0.tgz",
@@ -3757,6 +4547,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/miniflare": {
@@ -4218,6 +5018,25 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -4256,6 +5075,20 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/openapi3-ts": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.4.0.tgz",
@@ -4290,6 +5123,55 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.5.5",
@@ -4331,6 +5213,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
     "node_modules/safe-buffer": {
@@ -4414,6 +5330,13 @@
         "@img/sharp-win32-x64": "0.33.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -4423,6 +5346,16 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -4430,6 +5363,20 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strnum": {
       "version": "1.0.5",
@@ -4448,6 +5395,50 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -4548,6 +5539,677 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -4555,6 +6217,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,8 @@
   "name": "kc3-backend",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.749.0",
@@ -19,6 +20,7 @@
     "@types/node": "^20.11.17",
     "tsx": "^4.7.1",
     "typescript": "^7.0.2",
+    "vitest": "^4.1.10",
     "wrangler": "^4.118.0"
   }
 }

--- a/backend/src/lib/postNews.test.ts
+++ b/backend/src/lib/postNews.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppConfig } from '../config/env.js';
+import type { Container } from '../di/container.js';
+import postNews from './postNews.js';
+
+const { getNewsMock } = vi.hoisted(() => ({
+  getNewsMock: vi.fn(),
+}));
+
+vi.mock('./getNews.js', () => ({
+  default: getNewsMock,
+}));
+
+const config: AppConfig = {
+  NODE_ENV: 'test',
+  FRONTEND_URL: 'https://example.com',
+  GEMINI_API_KEY: 'gemini-key',
+  NEWS_POST_API_KEY: 'news-api-key',
+  NEWS_USER_ID: 'news-user',
+  S3_ACCESS_KEY_ID: 's3-access-key',
+  S3_SECRET_ACCESS_KEY: 's3-secret-key',
+  S3_BUCKET_NAME: 'bucket',
+  CDN_URL: 'https://cdn.example.com',
+  OUR_ID: 'our-user',
+  DEFAULT_ICON_PATH: 'icons/default.png',
+};
+
+const createContainer = () => {
+  const createPost = vi.fn();
+  const container = {
+    postService: {
+      createPost,
+    },
+  } as unknown as Container;
+
+  return { container, createPost };
+};
+
+describe('postNews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('APIキーが一致しない場合はニュースを取得せず認証失敗を返す', async () => {
+    const { container, createPost } = createContainer();
+
+    const result = await postNews('wrong-key', container, config);
+
+    expect(result).toEqual({
+      isAuthorized: false,
+      isSuccess: false,
+      tanka: {
+        line0: 'APIキーが間違っています',
+        line1: '',
+        line2: '',
+        line3: '',
+        line4: '',
+      },
+    });
+    expect(getNewsMock).not.toHaveBeenCalled();
+    expect(createPost).not.toHaveBeenCalled();
+  });
+
+  it('ニュース取得に失敗した場合は投稿せず失敗結果を返す', async () => {
+    const { container, createPost } = createContainer();
+    getNewsMock.mockResolvedValue({ isSuccess: false, message: 'RSS unavailable' });
+
+    const result = await postNews('news-api-key', container, config);
+
+    expect(result).toEqual({
+      isAuthorized: true,
+      isSuccess: false,
+      tanka: {
+        line0: 'ニュースの取得に失敗しました',
+        line1: '',
+        line2: '',
+        line3: '',
+        line4: '',
+      },
+    });
+    expect(getNewsMock).toHaveBeenCalledWith('test');
+    expect(createPost).not.toHaveBeenCalled();
+  });
+
+  it('取得したニュースを投稿し、短歌を行ごとのオブジェクトで返す', async () => {
+    const { container, createPost } = createContainer();
+    getNewsMock.mockResolvedValue({
+      isSuccess: true,
+      news: {
+        title: 'ニュースタイトル',
+        description: 'ニュース本文',
+        url: 'https://news.example.com/article',
+      },
+    });
+    createPost.mockResolvedValue({
+      message: '投稿しました．',
+      tanka: ['一の句', '二の句', '三の句', '四の句', '五の句'],
+    });
+
+    const result = await postNews('news-api-key', container, config);
+
+    expect(result).toEqual({
+      isAuthorized: true,
+      isSuccess: true,
+      tanka: {
+        line0: '一の句',
+        line1: '二の句',
+        line2: '三の句',
+        line3: '四の句',
+        line4: '五の句',
+      },
+    });
+    expect(getNewsMock).toHaveBeenCalledWith('test');
+    expect(createPost).toHaveBeenCalledWith({
+      original: 'ニュースタイトル\nニュース本文\nhttps://news.example.com/article',
+      image: null,
+      user_id: 'news-user',
+    });
+  });
+});

--- a/backend/src/services/follow/followService.test.ts
+++ b/backend/src/services/follow/followService.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IFollowRepository } from '../../repositories/follow/iFollowRepository.js';
+import { FollowError } from './iFollowService.js';
+import { FollowService } from './followService.js';
+
+const createService = () => {
+  const repository = {
+    createFollow: vi.fn(),
+    deleteFollow: vi.fn(),
+    isFollowing: vi.fn(),
+  } as unknown as IFollowRepository;
+
+  return { repository, service: new FollowService(repository) };
+};
+
+describe('FollowService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  describe('followUser', () => {
+    it('フォロー関係を作成して成功を返す', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockResolvedValue(false);
+
+      const result = await service.followUser('follower-1', 'followee-1');
+
+      expect(result).toEqual({ success: true });
+      expect(repository.isFollowing).toHaveBeenCalledWith('follower-1', 'followee-1');
+      expect(repository.createFollow).toHaveBeenCalledWith('follower-1', 'followee-1');
+    });
+
+    it('自分自身へのフォローはリポジトリを呼ばずエラー結果を返す', async () => {
+      const { repository, service } = createService();
+
+      const result = await service.followUser('user-1', 'user-1');
+
+      expect(result).toEqual({
+        success: false,
+        error: FollowError.SELF_FOLLOW,
+        message: '自分自身をフォローすることはできません',
+      });
+      expect(repository.isFollowing).not.toHaveBeenCalled();
+      expect(repository.createFollow).not.toHaveBeenCalled();
+    });
+
+    it('既存のフォロー関係がある場合はエラー結果を返す', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockResolvedValue(true);
+
+      const result = await service.followUser('follower-1', 'followee-1');
+
+      expect(result).toEqual({
+        success: false,
+        error: FollowError.ALREADY_FOLLOWING,
+        message: '既にフォローしています',
+      });
+      expect(repository.isFollowing).toHaveBeenCalledWith('follower-1', 'followee-1');
+      expect(repository.createFollow).not.toHaveBeenCalled();
+    });
+
+    it('外部キー制約エラーをユーザー不在の結果へ変換する', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockResolvedValue(false);
+      vi.mocked(repository.createFollow).mockRejectedValue({ code: 'ER_NO_REFERENCED_ROW_2' });
+
+      const result = await service.followUser('follower-1', 'missing-user');
+
+      expect(result).toEqual({
+        success: false,
+        error: FollowError.USER_NOT_FOUND,
+        message: 'ユーザーが見つかりません',
+      });
+      expect(repository.createFollow).toHaveBeenCalledWith('follower-1', 'missing-user');
+    });
+
+    it('その他の例外をデータベースエラー結果へ変換する', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockRejectedValue(new Error('connection lost'));
+
+      const result = await service.followUser('follower-1', 'followee-1');
+
+      expect(result).toEqual({
+        success: false,
+        error: FollowError.DATABASE_ERROR,
+        message: 'データベースエラーが発生しました',
+      });
+      expect(repository.isFollowing).toHaveBeenCalledWith('follower-1', 'followee-1');
+      expect(repository.createFollow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unfollowUser', () => {
+    it('フォロー関係を削除して成功を返す', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockResolvedValue(true);
+
+      const result = await service.unfollowUser('follower-1', 'followee-1');
+
+      expect(result).toEqual({ success: true });
+      expect(repository.isFollowing).toHaveBeenCalledWith('follower-1', 'followee-1');
+      expect(repository.deleteFollow).toHaveBeenCalledWith('follower-1', 'followee-1');
+    });
+
+    it('フォロー関係がない場合はエラー結果を返す', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockResolvedValue(false);
+
+      const result = await service.unfollowUser('follower-1', 'followee-1');
+
+      expect(result).toEqual({
+        success: false,
+        error: FollowError.NOT_FOLLOWING,
+        message: 'フォロー関係が存在しません',
+      });
+      expect(repository.isFollowing).toHaveBeenCalledWith('follower-1', 'followee-1');
+      expect(repository.deleteFollow).not.toHaveBeenCalled();
+    });
+
+    it('例外をデータベースエラー結果へ変換する', async () => {
+      const { repository, service } = createService();
+      vi.mocked(repository.isFollowing).mockResolvedValue(true);
+      vi.mocked(repository.deleteFollow).mockRejectedValue(new Error('connection lost'));
+
+      const result = await service.unfollowUser('follower-1', 'followee-1');
+
+      expect(result).toEqual({
+        success: false,
+        error: FollowError.DATABASE_ERROR,
+        message: 'データベースエラーが発生しました',
+      });
+      expect(repository.deleteFollow).toHaveBeenCalledWith('follower-1', 'followee-1');
+    });
+  });
+});

--- a/backend/src/services/miyabi/miyabiService.test.ts
+++ b/backend/src/services/miyabi/miyabiService.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMiyabiRepository, Miyabi } from '../../repositories/miyabi/iMiyabiRepository.js';
+import type { IPostRepository, Post } from '../../repositories/post/iPostRepository.js';
+import type { IUserRepository, User } from '../../repositories/user/iUserRepository.js';
+import { ConflictError, NotFoundError } from './iMiyabiService.js';
+import { MiyabiService } from './miyabiService.js';
+
+const { dbc, transactionMock } = vi.hoisted(() => {
+  const connection = { id: 'transaction-connection' };
+  return {
+    dbc: connection,
+    transactionMock: vi.fn(async (callback: (value: typeof connection) => Promise<unknown>) =>
+      callback(connection)
+    ),
+  };
+});
+
+vi.mock('../../lib/db.js', () => ({
+  default: {
+    transaction: transactionMock,
+  },
+}));
+
+const post: Post = {
+  id: 'post-1',
+  original: '原文',
+  tanka: ['一', '二', '三', '四', '五'],
+  image_path: null,
+  created_at: new Date('2025-01-01T00:00:00Z'),
+  user_id: 'author-1',
+  user_name: '作者',
+  user_icon: 'icons/author.png',
+  is_developer: false,
+  miyabi_count: 1,
+  is_miyabi: false,
+};
+
+const user: User = {
+  id: 'user-1',
+  name: 'ユーザー',
+  oauth_app: 'github',
+  connect_info: 'user@example.com',
+  profile_text: null,
+  icon_url: 'icons/user.png',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+};
+
+const miyabi: Miyabi = {
+  id: 'miyabi-1',
+  user_id: 'user-1',
+  post_id: 'post-1',
+  created_at: new Date('2025-01-02T00:00:00Z'),
+};
+
+const createDependencies = () => {
+  const miyabiRepository = {
+    findMiyabi: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    getMiyabiRanking: vi.fn(),
+  } as unknown as IMiyabiRepository;
+  const postRepository = {
+    findById: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    getPost: vi.fn(),
+    getOnePost: vi.fn(),
+    getFollowingPost: vi.fn(),
+  } as unknown as IPostRepository;
+  const userRepository = {
+    findByEmail: vi.fn(),
+    findById: vi.fn(),
+    findByOldIconUrl: vi.fn(),
+    create: vi.fn(),
+    updateConnectInfoAndIcon: vi.fn(),
+  } as unknown as IUserRepository;
+
+  return {
+    miyabiRepository,
+    postRepository,
+    userRepository,
+    service: new MiyabiService(miyabiRepository, postRepository, userRepository),
+  };
+};
+
+describe('MiyabiService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createMiyabi', () => {
+    it('トランザクション内で雅を作成して結果を返す', async () => {
+      const { service, miyabiRepository, postRepository, userRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      vi.mocked(miyabiRepository.findMiyabi).mockResolvedValue(null);
+
+      const result = await service.createMiyabi({ user_id: 'user-1', post_id: 'post-1' });
+
+      expect(result).toEqual({ message: '雅を作成しました．' });
+      expect(transactionMock).toHaveBeenCalledOnce();
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1', dbc);
+      expect(userRepository.findById).toHaveBeenCalledWith('user-1', dbc);
+      expect(miyabiRepository.findMiyabi).toHaveBeenCalledWith('user-1', 'post-1', dbc);
+      expect(miyabiRepository.create).toHaveBeenCalledWith('user-1', 'post-1', dbc);
+    });
+
+    it('投稿が存在しない場合はNotFoundErrorを投げる', async () => {
+      const { service, miyabiRepository, postRepository, userRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(null);
+
+      const error = await service
+        .createMiyabi({ user_id: 'user-1', post_id: 'post-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error).toMatchObject({ name: 'NotFoundError', message: '投稿が見つかりません．' });
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1', dbc);
+      expect(userRepository.findById).not.toHaveBeenCalled();
+      expect(miyabiRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('ユーザーが存在しない場合はNotFoundErrorを投げる', async () => {
+      const { service, miyabiRepository, postRepository, userRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+      vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+      const error = await service
+        .createMiyabi({ user_id: 'user-1', post_id: 'post-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1', dbc);
+      expect(userRepository.findById).toHaveBeenCalledWith('user-1', dbc);
+      expect(miyabiRepository.findMiyabi).not.toHaveBeenCalled();
+      expect(miyabiRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('雅が既に存在する場合はConflictErrorを投げる', async () => {
+      const { service, miyabiRepository, postRepository, userRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      vi.mocked(miyabiRepository.findMiyabi).mockResolvedValue(miyabi);
+
+      const error = await service
+        .createMiyabi({ user_id: 'user-1', post_id: 'post-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(ConflictError);
+      expect(error).toMatchObject({ name: 'ConflictError', message: '雅が既に存在します．' });
+      expect(miyabiRepository.findMiyabi).toHaveBeenCalledWith('user-1', 'post-1', dbc);
+      expect(miyabiRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteMiyabi', () => {
+    it('トランザクション内で雅を削除して結果を返す', async () => {
+      const { service, miyabiRepository, postRepository, userRepository } = createDependencies();
+      vi.mocked(miyabiRepository.findMiyabi).mockResolvedValue(miyabi);
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+
+      const result = await service.deleteMiyabi({ user_id: 'user-1', post_id: 'post-1' });
+
+      expect(result).toEqual({ message: '雅を削除しました．' });
+      expect(miyabiRepository.findMiyabi).toHaveBeenCalledWith('user-1', 'post-1', dbc);
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1', dbc);
+      expect(userRepository.findById).toHaveBeenCalledWith('user-1', dbc);
+      expect(miyabiRepository.delete).toHaveBeenCalledWith('user-1', 'post-1', dbc);
+    });
+
+    it('雅が存在しない場合は投稿とユーザーを確認した後にConflictErrorを投げる', async () => {
+      const { service, miyabiRepository, postRepository, userRepository } = createDependencies();
+      vi.mocked(miyabiRepository.findMiyabi).mockResolvedValue(null);
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+
+      const error = await service
+        .deleteMiyabi({ user_id: 'user-1', post_id: 'post-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(ConflictError);
+      expect(error).toMatchObject({ name: 'ConflictError', message: '雅が見つかりません．' });
+      expect(miyabiRepository.findMiyabi).toHaveBeenCalledWith('user-1', 'post-1', dbc);
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1', dbc);
+      expect(userRepository.findById).toHaveBeenCalledWith('user-1', dbc);
+      expect(miyabiRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  it('getMiyabiRankingはリポジトリのランキングを返す', async () => {
+    const { service, miyabiRepository } = createDependencies();
+    const ranking = [
+      {
+        rank: 1,
+        ...post,
+        miyabi_count: 10,
+      },
+    ];
+    vi.mocked(miyabiRepository.getMiyabiRanking).mockResolvedValue(ranking);
+
+    const result = await service.getMiyabiRanking({ limit: 20, viewerId: 'viewer-1' });
+
+    expect(result).toEqual(ranking);
+    expect(miyabiRepository.getMiyabiRanking).toHaveBeenCalledWith(20, 'viewer-1');
+  });
+});

--- a/backend/src/services/post/postService.test.ts
+++ b/backend/src/services/post/postService.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IImageService } from '../image/iImageService.js';
+import type { IPostRepository, Post } from '../../repositories/post/iPostRepository.js';
+import type { IUserRepository, User } from '../../repositories/user/iUserRepository.js';
+import { NotFoundError } from './iPostService.js';
+import { PostService } from './postService.js';
+
+const { compressImageMock, generateTankaMock } = vi.hoisted(() => ({
+  compressImageMock: vi.fn(),
+  generateTankaMock: vi.fn(),
+}));
+
+vi.mock('../../lib/gemini.js', () => ({
+  default: generateTankaMock,
+}));
+
+vi.mock('../../utils/compressImage.js', () => ({
+  compressImage: compressImageMock,
+}));
+
+const tanka = ['春の風', '川面をわたり', '花ゆれて', '遠き山まで', '光をはこぶ'];
+
+const post: Post = {
+  id: 'post-1',
+  original: '春のニュース',
+  tanka,
+  image_path: null,
+  created_at: new Date('2025-01-01T00:00:00Z'),
+  user_id: 'user-1',
+  user_name: 'ユーザー',
+  user_icon: 'icons/user.png',
+  is_developer: false,
+  miyabi_count: 2,
+  is_miyabi: true,
+};
+
+const user: User = {
+  id: 'viewer-1',
+  name: '閲覧者',
+  oauth_app: 'github',
+  connect_info: 'viewer@example.com',
+  profile_text: null,
+  icon_url: 'icons/viewer.png',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+};
+
+const createDependencies = () => {
+  const postRepository = {
+    findById: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    getPost: vi.fn(),
+    getOnePost: vi.fn(),
+    getFollowingPost: vi.fn(),
+  } as unknown as IPostRepository;
+  const imageService = {
+    uploadImage: vi.fn(),
+    getImage: vi.fn(),
+    isImage: vi.fn(),
+  } as unknown as IImageService;
+  const userRepository = {
+    findByEmail: vi.fn(),
+    findById: vi.fn(),
+    findByOldIconUrl: vi.fn(),
+    create: vi.fn(),
+    updateConnectInfoAndIcon: vi.fn(),
+  } as unknown as IUserRepository;
+
+  return {
+    postRepository,
+    imageService,
+    userRepository,
+    service: new PostService(postRepository, imageService, userRepository, 'gemini-key'),
+  };
+};
+
+describe('PostService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateTankaMock.mockResolvedValue({ isSuccess: true, tanka });
+    compressImageMock.mockImplementation(async (file: File) => file);
+  });
+
+  describe('createPost', () => {
+    it('画像なしで短歌を生成し投稿を作成する', async () => {
+      const { service, postRepository, imageService } = createDependencies();
+
+      const result = await service.createPost({
+        original: '春のニュース',
+        image: null,
+        user_id: 'user-1',
+      });
+
+      expect(result).toEqual({ message: '投稿しました．', tanka });
+      expect(compressImageMock).not.toHaveBeenCalled();
+      expect(imageService.uploadImage).not.toHaveBeenCalled();
+      expect(generateTankaMock).toHaveBeenCalledWith('春のニュース', null, 'gemini-key');
+      expect(postRepository.create).toHaveBeenCalledWith({
+        original: '春のニュース',
+        tanka,
+        image_path: null,
+        user_id: 'user-1',
+      });
+    });
+
+    it('画像を圧縮・アップロードして生成した短歌とともに投稿を作成する', async () => {
+      const { service, postRepository, imageService } = createDependencies();
+      const image = new File(['image'], 'photo.png', { type: 'image/png' });
+      const compressedImage = new File(['compressed'], 'photo.webp', { type: 'image/webp' });
+      compressImageMock.mockResolvedValue(compressedImage);
+      vi.mocked(imageService.uploadImage).mockResolvedValue('posts/photo.webp');
+
+      const result = await service.createPost({
+        original: '春のニュース',
+        image,
+        user_id: 'user-1',
+      });
+
+      expect(result).toEqual({ message: '投稿しました．', tanka });
+      expect(compressImageMock).toHaveBeenCalledWith(image);
+      expect(imageService.uploadImage).toHaveBeenCalledWith(compressedImage);
+      expect(generateTankaMock).toHaveBeenCalledWith(
+        '春のニュース',
+        compressedImage,
+        'gemini-key'
+      );
+      expect(postRepository.create).toHaveBeenCalledWith({
+        original: '春のニュース',
+        tanka,
+        image_path: 'posts/photo.webp',
+        user_id: 'user-1',
+      });
+    });
+
+    it('短歌生成の失敗結果をメッセージ付きErrorとして投げる', async () => {
+      const { service, postRepository } = createDependencies();
+      generateTankaMock.mockResolvedValue({ isSuccess: false, message: 'quota exceeded' });
+
+      const error = await service
+        .createPost({ original: '春のニュース', image: null, user_id: 'user-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        name: 'Error',
+        message: '短歌の生成に失敗しました: quota exceeded',
+      });
+      expect(generateTankaMock).toHaveBeenCalledWith('春のニュース', null, 'gemini-key');
+      expect(postRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deletePost', () => {
+    it('投稿者本人の投稿を削除して結果を返す', async () => {
+      const { service, postRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+
+      const result = await service.deletePost({ post_id: 'post-1', user_id: 'user-1' });
+
+      expect(result).toEqual({ message: '投稿を削除しました．' });
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1');
+      expect(postRepository.delete).toHaveBeenCalledWith('post-1', 'user-1');
+    });
+
+    it('投稿が存在しない場合はErrorを投げる', async () => {
+      const { service, postRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(null);
+
+      const error = await service
+        .deletePost({ post_id: 'missing-post', user_id: 'user-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({ name: 'Error', message: '投稿が見つかりません．' });
+      expect(postRepository.findById).toHaveBeenCalledWith('missing-post');
+      expect(postRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('投稿者以外からの削除ではErrorを投げる', async () => {
+      const { service, postRepository } = createDependencies();
+      vi.mocked(postRepository.findById).mockResolvedValue(post);
+
+      const error = await service
+        .deletePost({ post_id: 'post-1', user_id: 'other-user' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({ name: 'Error', message: '許可がありません．' });
+      expect(postRepository.findById).toHaveBeenCalledWith('post-1');
+      expect(postRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  it('getPostはDTOをそのままリポジトリへ渡して投稿一覧を返す', async () => {
+    const { service, postRepository } = createDependencies();
+    const dto = {
+      limit: 10,
+      cursor: 'cursor-1',
+      filterByUserId: 'user-1',
+      viewerId: 'viewer-1',
+    };
+    vi.mocked(postRepository.getPost).mockResolvedValue([post]);
+
+    const result = await service.getPost(dto);
+
+    expect(result).toEqual([post]);
+    expect(postRepository.getPost).toHaveBeenCalledWith(dto);
+  });
+
+  it('getOnePostは投稿IDと閲覧者IDを渡して投稿を返す', async () => {
+    const { service, postRepository } = createDependencies();
+    vi.mocked(postRepository.getOnePost).mockResolvedValue(post);
+
+    const result = await service.getOnePost({ id: 'post-1', viewerId: 'viewer-1' });
+
+    expect(result).toEqual(post);
+    expect(postRepository.getOnePost).toHaveBeenCalledWith('post-1', 'viewer-1');
+  });
+
+  describe('getFollowingPost', () => {
+    it('閲覧者を確認してフォロー中ユーザーの投稿一覧を返す', async () => {
+      const { service, postRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      vi.mocked(postRepository.getFollowingPost).mockResolvedValue([post]);
+
+      const result = await service.getFollowingPost({
+        limit: 20,
+        viewerId: 'viewer-1',
+        cursor: 'cursor-1',
+      });
+
+      expect(result).toEqual([post]);
+      expect(userRepository.findById).toHaveBeenCalledWith('viewer-1');
+      expect(postRepository.getFollowingPost).toHaveBeenCalledWith(
+        20,
+        'viewer-1',
+        'cursor-1'
+      );
+    });
+
+    it('閲覧者が存在しない場合はNotFoundErrorを投げる', async () => {
+      const { service, postRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+      const error = await service
+        .getFollowingPost({ limit: 20, viewerId: 'missing-viewer' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+      expect(userRepository.findById).toHaveBeenCalledWith('missing-viewer');
+      expect(postRepository.getFollowingPost).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/services/profile/profileService.test.ts
+++ b/backend/src/services/profile/profileService.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IIconService } from '../icon/iIconService.js';
+import type { IProfileRepository, Profile } from '../../repositories/profile/iProfileRepository.js';
+import type { IUserRepository, User } from '../../repositories/user/iUserRepository.js';
+import { NotFoundError } from './iProfileService.js';
+import { ProfileService } from './profileService.js';
+
+const { compressIconImageMock } = vi.hoisted(() => ({
+  compressIconImageMock: vi.fn(),
+}));
+
+vi.mock('../../utils/compressImage.js', () => ({
+  compressIconImage: compressIconImageMock,
+}));
+
+const user: User = {
+  id: 'user-1',
+  name: 'ユーザー',
+  oauth_app: 'github',
+  connect_info: 'user@example.com',
+  profile_text: '自己紹介',
+  icon_url: 'icons/current.png',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+};
+
+const viewer: User = {
+  ...user,
+  id: 'viewer-1',
+  connect_info: 'viewer@example.com',
+};
+
+const profile: Profile = {
+  user_id: 'user-1',
+  user_name: 'ユーザー',
+  profile_text: '自己紹介',
+  icon_url: 'icons/current.png',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+  is_developer: false,
+  total_miyabi: 12,
+  total_post: 3,
+  following_count: 4,
+  follower_count: 5,
+  is_following: true,
+};
+
+const createDependencies = () => {
+  const profileRepository = {
+    getProfile: vi.fn(),
+    updateProfile: vi.fn(),
+    getFollowingUser: vi.fn(),
+    getMutualFollowingUser: vi.fn(),
+  } as unknown as IProfileRepository;
+  const userRepository = {
+    findByEmail: vi.fn(),
+    findById: vi.fn(),
+    findByOldIconUrl: vi.fn(),
+    create: vi.fn(),
+    updateConnectInfoAndIcon: vi.fn(),
+  } as unknown as IUserRepository;
+  const iconService = {
+    updatedIcon: vi.fn(),
+    getIcon: vi.fn(),
+  } as unknown as IIconService;
+
+  return {
+    profileRepository,
+    userRepository,
+    iconService,
+    service: new ProfileService(profileRepository, userRepository, iconService),
+  };
+};
+
+describe('ProfileService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    compressIconImageMock.mockImplementation(async (file: File) => file);
+  });
+
+  describe('getProfile', () => {
+    it('対象ユーザーと閲覧者を確認してプロフィールを返す', async () => {
+      const { service, profileRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById)
+        .mockResolvedValueOnce(user)
+        .mockResolvedValueOnce(viewer);
+      vi.mocked(profileRepository.getProfile).mockResolvedValue(profile);
+
+      const result = await service.getProfile({ user_id: 'user-1', viewer_id: 'viewer-1' });
+
+      expect(result).toEqual(profile);
+      expect(userRepository.findById).toHaveBeenNthCalledWith(1, 'user-1');
+      expect(userRepository.findById).toHaveBeenNthCalledWith(2, 'viewer-1');
+      expect(profileRepository.getProfile).toHaveBeenCalledWith('user-1', 'viewer-1');
+    });
+
+    it('閲覧者が未指定の場合は対象ユーザーだけを確認する', async () => {
+      const { service, profileRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      vi.mocked(profileRepository.getProfile).mockResolvedValue(profile);
+
+      const result = await service.getProfile({ user_id: 'user-1' });
+
+      expect(result).toEqual(profile);
+      expect(userRepository.findById).toHaveBeenCalledOnce();
+      expect(userRepository.findById).toHaveBeenCalledWith('user-1');
+      expect(profileRepository.getProfile).toHaveBeenCalledWith('user-1', undefined);
+    });
+
+    it('対象ユーザーが存在しない場合はNotFoundErrorを投げる', async () => {
+      const { service, profileRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+      const error = await service
+        .getProfile({ user_id: 'missing-user', viewer_id: 'viewer-1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+      expect(userRepository.findById).toHaveBeenCalledWith('missing-user');
+      expect(profileRepository.getProfile).not.toHaveBeenCalled();
+    });
+
+    it('閲覧者が存在しない場合はNotFoundErrorを投げる', async () => {
+      const { service, profileRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById).mockResolvedValueOnce(user).mockResolvedValueOnce(null);
+
+      const error = await service
+        .getProfile({ user_id: 'user-1', viewer_id: 'missing-viewer' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+      expect(userRepository.findById).toHaveBeenNthCalledWith(1, 'user-1');
+      expect(userRepository.findById).toHaveBeenNthCalledWith(2, 'missing-viewer');
+      expect(profileRepository.getProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('アイコン未指定の場合は現在のアイコンでプロフィールを更新する', async () => {
+      const { service, profileRepository, userRepository, iconService } = createDependencies();
+      const updatedProfile = { ...profile, user_name: '更新名', profile_text: '更新文' };
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      vi.mocked(profileRepository.getProfile).mockResolvedValue(updatedProfile);
+
+      const result = await service.updateProfile({
+        user_id: 'user-1',
+        user_name: '更新名',
+        profile_text: '更新文',
+        icon_image: null,
+      });
+
+      expect(result).toEqual(updatedProfile);
+      expect(iconService.updatedIcon).not.toHaveBeenCalled();
+      expect(profileRepository.updateProfile).toHaveBeenCalledWith({
+        user_id: 'user-1',
+        user_name: '更新名',
+        profile_text: '更新文',
+        image_path: 'icons/current.png',
+      });
+      expect(profileRepository.getProfile).toHaveBeenCalledWith('user-1', 'user-1');
+    });
+
+    it('新しいアイコンを圧縮・アップロードしてそのパスで更新する', async () => {
+      const { service, profileRepository, userRepository, iconService } = createDependencies();
+      const icon = new File(['new icon'], 'icon.png', { type: 'image/png' });
+      const compressedIcon = new File(['compressed'], 'icon.webp', { type: 'image/webp' });
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      compressIconImageMock.mockResolvedValue(compressedIcon);
+      vi.mocked(iconService.updatedIcon).mockResolvedValue('icons/new.png');
+      vi.mocked(profileRepository.getProfile).mockResolvedValue({
+        ...profile,
+        icon_url: 'icons/new.png',
+      });
+
+      const result = await service.updateProfile({
+        user_id: 'user-1',
+        user_name: '更新名',
+        profile_text: '更新文',
+        icon_image: icon,
+      });
+
+      expect(result.icon_url).toBe('icons/new.png');
+      expect(compressIconImageMock).toHaveBeenCalledWith(icon);
+      expect(iconService.updatedIcon).toHaveBeenCalledWith(compressedIcon, 'user-1');
+      expect(profileRepository.updateProfile).toHaveBeenCalledWith({
+        user_id: 'user-1',
+        user_name: '更新名',
+        profile_text: '更新文',
+        image_path: 'icons/new.png',
+      });
+    });
+
+    it('アイコンアップロードに失敗した場合は現在のアイコンで更新する', async () => {
+      const { service, profileRepository, userRepository, iconService } = createDependencies();
+      const icon = new File(['new icon'], 'icon.png', { type: 'image/png' });
+      vi.mocked(userRepository.findById).mockResolvedValue(user);
+      vi.mocked(iconService.updatedIcon).mockRejectedValue(new Error('S3 unavailable'));
+      vi.mocked(profileRepository.getProfile).mockResolvedValue(profile);
+
+      const result = await service.updateProfile({
+        user_id: 'user-1',
+        user_name: '更新名',
+        profile_text: '更新文',
+        icon_image: icon,
+      });
+
+      expect(result).toEqual(profile);
+      expect(iconService.updatedIcon).toHaveBeenCalledWith(icon, 'user-1');
+      expect(profileRepository.updateProfile).toHaveBeenCalledWith({
+        user_id: 'user-1',
+        user_name: '更新名',
+        profile_text: '更新文',
+        image_path: 'icons/current.png',
+      });
+    });
+
+    it('ユーザーが存在しない場合はNotFoundErrorを投げる', async () => {
+      const { service, profileRepository, userRepository } = createDependencies();
+      vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+      const error = await service
+        .updateProfile({
+          user_id: 'missing-user',
+          user_name: '更新名',
+          profile_text: '更新文',
+          icon_image: null,
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+      expect(userRepository.findById).toHaveBeenCalledWith('missing-user');
+      expect(profileRepository.updateProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  it('getFollowingUserはユーザー確認後にリポジトリの一覧を返す', async () => {
+    const { service, profileRepository, userRepository } = createDependencies();
+    const dto = { user_id: 'user-1', viewer_id: 'viewer-1', limit: 10, cursor: 'cursor-1' };
+    vi.mocked(userRepository.findById).mockResolvedValue(user);
+    vi.mocked(profileRepository.getFollowingUser).mockResolvedValue([profile]);
+
+    const result = await service.getFollowingUser(dto);
+
+    expect(result).toEqual([profile]);
+    expect(userRepository.findById).toHaveBeenCalledWith('user-1');
+    expect(profileRepository.getFollowingUser).toHaveBeenCalledWith(dto);
+  });
+
+  it('getFollowingUserはユーザー不在時にNotFoundErrorを投げる', async () => {
+    const { service, profileRepository, userRepository } = createDependencies();
+    const dto = { user_id: 'missing-user', limit: 10 };
+    vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+    const error = await service.getFollowingUser(dto).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+    expect(userRepository.findById).toHaveBeenCalledWith('missing-user');
+    expect(profileRepository.getFollowingUser).not.toHaveBeenCalled();
+  });
+
+  it('getMutualFollowingUserはユーザー確認後にリポジトリの一覧を返す', async () => {
+    const { service, profileRepository, userRepository } = createDependencies();
+    const dto = { user_id: 'user-1', viewer_id: 'viewer-1', limit: 5, cursor: 'cursor-1' };
+    vi.mocked(userRepository.findById).mockResolvedValue(user);
+    vi.mocked(profileRepository.getMutualFollowingUser).mockResolvedValue([profile]);
+
+    const result = await service.getMutualFollowingUser(dto);
+
+    expect(result).toEqual([profile]);
+    expect(userRepository.findById).toHaveBeenCalledWith('user-1');
+    expect(profileRepository.getMutualFollowingUser).toHaveBeenCalledWith(dto);
+  });
+
+  it('getMutualFollowingUserはユーザー不在時にNotFoundErrorを投げる', async () => {
+    const { service, profileRepository, userRepository } = createDependencies();
+    const dto = { user_id: 'missing-user', limit: 5 };
+    vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+    const error = await service.getMutualFollowingUser(dto).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error).toMatchObject({ name: 'NotFoundError', message: 'ユーザーが見つかりません．' });
+    expect(userRepository.findById).toHaveBeenCalledWith('missing-user');
+    expect(profileRepository.getMutualFollowingUser).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/user/userService.test.ts
+++ b/backend/src/services/user/userService.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IIconService } from '../icon/iIconService.js';
+import type { IUserRepository, User } from '../../repositories/user/iUserRepository.js';
+import type { CreateUserDTO } from './iUserService.js';
+import { UserService } from './userService.js';
+
+const { compressIconImageMock, generateUuidMock } = vi.hoisted(() => ({
+  compressIconImageMock: vi.fn(),
+  generateUuidMock: vi.fn(),
+}));
+
+vi.mock('../../utils/compressImage.js', () => ({
+  compressIconImage: compressIconImageMock,
+}));
+
+vi.mock('../../utils/generateUuid.js', () => ({
+  generateUuid: generateUuidMock,
+}));
+
+const userDto: CreateUserDTO = {
+  name: '新しいユーザー',
+  oauth_app: 'github',
+  connect_info: 'new@example.com',
+  profile_text: '自己紹介',
+  icon_url: 'https://example.com/icon.png',
+};
+
+const existingUser: User = {
+  id: 'existing-user',
+  name: '既存ユーザー',
+  oauth_app: 'github',
+  connect_info: 'new@example.com',
+  profile_text: '既存の自己紹介',
+  icon_url: 'icons/existing.png',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+};
+
+const createDependencies = () => {
+  const userRepository = {
+    findByEmail: vi.fn(),
+    findById: vi.fn(),
+    findByOldIconUrl: vi.fn(),
+    create: vi.fn(),
+    updateConnectInfoAndIcon: vi.fn(),
+  } as unknown as IUserRepository;
+  const iconService = {
+    updatedIcon: vi.fn(),
+    getIcon: vi.fn(),
+  } as unknown as IIconService;
+
+  return {
+    userRepository,
+    iconService,
+    service: new UserService(userRepository, iconService, 'icons/default.png'),
+  };
+};
+
+describe('UserService#createUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    generateUuidMock.mockReturnValue('generated-user');
+    compressIconImageMock.mockImplementation(async (file: File) => file);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(new Blob(['icon']), { status: 200 }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('メールアドレスとOAuthアプリが一致する既存ユーザーをそのまま返す', async () => {
+    const { service, userRepository, iconService } = createDependencies();
+    vi.mocked(userRepository.findByEmail).mockResolvedValue(existingUser);
+
+    const result = await service.createUser(userDto);
+
+    expect(result).toEqual({ user: existingUser, type: 'existing' });
+    expect(userRepository.findByEmail).toHaveBeenCalledWith('new@example.com', 'github');
+    expect(userRepository.findByOldIconUrl).not.toHaveBeenCalled();
+    expect(userRepository.create).not.toHaveBeenCalled();
+    expect(iconService.updatedIcon).not.toHaveBeenCalled();
+  });
+
+  it('旧アイコンURLが一致するユーザーを移行して返す', async () => {
+    const { service, userRepository, iconService } = createDependencies();
+    const migratedUser = {
+      ...existingUser,
+      connect_info: 'new@example.com',
+      icon_url: 'icons/migrated.png',
+    };
+    vi.mocked(userRepository.findByEmail).mockResolvedValue(null);
+    vi.mocked(userRepository.findByOldIconUrl).mockResolvedValue(existingUser);
+    vi.mocked(userRepository.findById).mockResolvedValue(migratedUser);
+    vi.mocked(iconService.updatedIcon).mockResolvedValue('icons/migrated.png');
+
+    const result = await service.createUser(userDto);
+
+    expect(result).toEqual({ user: migratedUser, type: 'migrated' });
+    expect(userRepository.findByOldIconUrl).toHaveBeenCalledWith('https://example.com/icon.png');
+    expect(iconService.updatedIcon).toHaveBeenCalledWith(expect.any(File), 'existing-user');
+    expect(userRepository.updateConnectInfoAndIcon).toHaveBeenCalledWith(
+      'existing-user',
+      'new@example.com',
+      'github',
+      'icons/migrated.png'
+    );
+    expect(userRepository.findById).toHaveBeenCalledWith('existing-user');
+    expect(userRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('新規ユーザーを作成し、再取得したユーザーを返す', async () => {
+    const { service, userRepository, iconService } = createDependencies();
+    const createdUser: User = {
+      ...existingUser,
+      id: 'generated-user',
+      name: '新しいユーザー',
+      profile_text: '自己紹介',
+      icon_url: 'icons/generated-user.png',
+    };
+    vi.mocked(userRepository.findByEmail)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(createdUser);
+    vi.mocked(userRepository.findByOldIconUrl).mockResolvedValue(null);
+    vi.mocked(iconService.updatedIcon).mockResolvedValue('icons/generated-user.png');
+
+    const result = await service.createUser(userDto);
+
+    expect(result).toEqual({ user: createdUser, type: 'created' });
+    expect(generateUuidMock).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith('https://example.com/icon.png');
+    expect(compressIconImageMock).toHaveBeenCalledWith(expect.any(File));
+    expect(iconService.updatedIcon).toHaveBeenCalledWith(expect.any(File), 'generated-user');
+    expect(userRepository.create).toHaveBeenCalledWith({
+      id: 'generated-user',
+      name: '新しいユーザー',
+      oauth_app: 'github',
+      connect_info: 'new@example.com',
+      profile_text: '自己紹介',
+      icon_url: 'icons/generated-user.png',
+    });
+    expect(userRepository.findByEmail).toHaveBeenNthCalledWith(1, 'new@example.com', 'github');
+    expect(userRepository.findByEmail).toHaveBeenNthCalledWith(2, 'new@example.com', 'github');
+  });
+
+  it('アイコンアップロードに失敗した場合はデフォルトアイコンで新規作成する', async () => {
+    const { service, userRepository, iconService } = createDependencies();
+    const createdUser: User = {
+      ...existingUser,
+      id: 'generated-user',
+      icon_url: 'icons/default.png',
+    };
+    vi.mocked(userRepository.findByEmail)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(createdUser);
+    vi.mocked(userRepository.findByOldIconUrl).mockResolvedValue(null);
+    vi.mocked(iconService.updatedIcon).mockRejectedValue(new Error('S3 unavailable'));
+
+    const result = await service.createUser(userDto);
+
+    expect(result).toEqual({ user: createdUser, type: 'created' });
+    expect(iconService.updatedIcon).toHaveBeenCalledWith(expect.any(File), 'generated-user');
+    expect(userRepository.create).toHaveBeenCalledWith({
+      id: 'generated-user',
+      name: '新しいユーザー',
+      oauth_app: 'github',
+      connect_info: 'new@example.com',
+      profile_text: '自己紹介',
+      icon_url: 'icons/default.png',
+    });
+  });
+
+  it('作成直後にユーザーを再取得できない場合はErrorを投げる', async () => {
+    const { service, userRepository, iconService } = createDependencies();
+    vi.mocked(userRepository.findByEmail).mockResolvedValue(null);
+    vi.mocked(userRepository.findByOldIconUrl).mockResolvedValue(null);
+    vi.mocked(iconService.updatedIcon).mockResolvedValue('icons/generated-user.png');
+
+    const error = await service.createUser(userDto).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({ name: 'Error', message: 'ユーザーの作成に失敗しました．' });
+    expect(userRepository.create).toHaveBeenCalledWith({
+      id: 'generated-user',
+      name: '新しいユーザー',
+      oauth_app: 'github',
+      connect_info: 'new@example.com',
+      profile_text: '自己紹介',
+      icon_url: 'icons/generated-user.png',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Pins current service-layer behavior with unit tests before the data layer is rewritten for D1.

## Changes
- Add vitest and a `test` script
- Add 45 characterization tests covering return shapes, repository call arguments and error types/messages for miyabi, follow, user, profile, post services and postNews

## Notes
- All external deps (DB, S3, Gemini, sharp) are mocked; `npm test` runs offline