### PR TITLE
feat: run the news tanka post on a Workers cron trigger

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ import {
   type Container,
 } from './di/container.js';
 import { DbClient } from './lib/dbClient.js';
-import { runNewsPost } from './lib/postNews.js';
+import { runScheduledNewsPost } from './lib/postNews.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import router from './routes/route.js';
 
@@ -68,7 +68,7 @@ const scheduled = (
   const config = parseConfig(env);
   const container = createContainer(config, new DbClient(env.DB));
 
-  ctx.waitUntil(runNewsPost(container, config));
+  ctx.waitUntil(runScheduledNewsPost(container, config));
 };
 
 export default { fetch: app.fetch, scheduled };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { swaggerUI } from '@hono/swagger-ui';
-import type { Context } from 'hono';
+import type { Context, ExecutionContext } from 'hono';
 import { env as getRuntimeEnv } from 'hono/adapter';
 import { cors } from 'hono/cors';
 import { parseConfig, type AppConfig } from './config/env.js';
@@ -10,6 +10,7 @@ import {
   type Container,
 } from './di/container.js';
 import { DbClient } from './lib/dbClient.js';
+import { runNewsPost } from './lib/postNews.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import router from './routes/route.js';
 
@@ -59,5 +60,16 @@ routedApp.get(
 
 routedApp.onError(errorHandler);
 
-export default app;
+const scheduled = (
+  _controller: unknown,
+  env: AppEnv['Bindings'],
+  ctx: ExecutionContext
+) => {
+  const config = parseConfig(env);
+  const container = createContainer(config, new DbClient(env.DB));
+
+  ctx.waitUntil(runNewsPost(container, config));
+};
+
+export default { fetch: app.fetch, scheduled };
 export type AppType = typeof routedApp;

--- a/backend/src/lib/postNews.test.ts
+++ b/backend/src/lib/postNews.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppConfig } from '../config/env.js';
 import type { Container } from '../di/container.js';
-import postNews from './postNews.js';
+import postNews, { runScheduledNewsPost } from './postNews.js';
 
 const { getNewsMock } = vi.hoisted(() => ({
   getNewsMock: vi.fn(),
@@ -117,5 +117,31 @@ describe('postNews', () => {
       image: null,
       user_id: 'news-user',
     });
+  });
+
+  it('cron実行でニュース取得に失敗した場合は理由を含むErrorをthrowする', async () => {
+    const { container } = createContainer();
+    getNewsMock.mockResolvedValue({ isSuccess: false, message: 'RSS unavailable' });
+
+    await expect(runScheduledNewsPost(container, config)).rejects.toThrow(
+      'ニュースの取得に失敗しました'
+    );
+  });
+
+  it('cron実行で投稿に失敗した場合は理由を含むErrorをthrowする', async () => {
+    const { container, createPost } = createContainer();
+    getNewsMock.mockResolvedValue({
+      isSuccess: true,
+      news: {
+        title: 'ニュースタイトル',
+        description: 'ニュース本文',
+        url: 'https://news.example.com/article',
+      },
+    });
+    createPost.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(runScheduledNewsPost(container, config)).rejects.toThrow(
+      '投稿に失敗しました'
+    );
   });
 });

--- a/backend/src/lib/postNews.ts
+++ b/backend/src/lib/postNews.ts
@@ -2,21 +2,7 @@ import type { AppConfig } from '../config/env.js';
 import type { Container } from '../di/container.js';
 import getNews from './getNews.js';
 
-const postNews = async (requestApiKey: string, container: Container, config: AppConfig) => {
-  if (requestApiKey !== config.NEWS_POST_API_KEY) {
-    return {
-      isAuthorized: false,
-      isSuccess: false,
-      tanka: {
-        line0: 'APIキーが間違っています',
-        line1: '',
-        line2: '',
-        line3: '',
-        line4: '',
-      },
-    };
-  }
-
+export const runNewsPost = async (container: Container, config: AppConfig) => {
   const newsResponse = await getNews(config.NODE_ENV);
 
   // ニュースの取得に失敗した場合
@@ -75,6 +61,24 @@ const postNews = async (requestApiKey: string, container: Container, config: App
       },
     };
   }
+};
+
+const postNews = async (requestApiKey: string, container: Container, config: AppConfig) => {
+  if (requestApiKey !== config.NEWS_POST_API_KEY) {
+    return {
+      isAuthorized: false,
+      isSuccess: false,
+      tanka: {
+        line0: 'APIキーが間違っています',
+        line1: '',
+        line2: '',
+        line3: '',
+        line4: '',
+      },
+    };
+  }
+
+  return runNewsPost(container, config);
 };
 
 export default postNews;

--- a/backend/src/lib/postNews.ts
+++ b/backend/src/lib/postNews.ts
@@ -63,6 +63,17 @@ export const runNewsPost = async (container: Container, config: AppConfig) => {
   }
 };
 
+export const runScheduledNewsPost = async (
+  container: Container,
+  config: AppConfig
+) => {
+  const result = await runNewsPost(container, config);
+
+  if (!result.isSuccess) {
+    throw new Error(result.tanka.line0);
+  }
+};
+
 const postNews = async (requestApiKey: string, container: Container, config: AppConfig) => {
   if (requestApiKey !== config.NEWS_POST_API_KEY) {
     return {


### PR DESCRIPTION
## Summary
Replaces the AWS Lambda that POSTed /news with a native scheduled handler.

## Changes
- Extract runNewsPost and call it from a scheduled handler via ctx.waitUntil
- Keep the key-checked POST /news route for manual triggering

## Notes
- Verified end-to-end locally (--test-scheduled): RSS fetch → Gemini generation (incl. syllable-validation retries) → D1 insert
- The cron expression is a placeholder — align it with the actual EventBridge schedule before cutover