### PR TITLE
chore: finalize Workers config for the production cutover

### DIFF
--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -9,7 +9,7 @@
       "binding": "DB",
       "database_name": "tankalizer",
       // デプロイ前に `wrangler d1 create tankalizer` で発行された ID に差し替える（ローカル開発はこのままで動く）
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      "database_id": "64267243-4327-4d66-a69f-487cca7fedef",
       "migrations_dir": "migrations"
     }
   ],
@@ -20,14 +20,12 @@
   "vars": {
     "NODE_ENV": "production",
     "FRONTEND_URL": "https://tankalizer.jp",
-    "S3_BUCKET_NAME": "tankalizer-images",
-    "CDN_URL": "image.tankalizer.jp",
-    "NEWS_USER_ID": "REPLACE_ME",
-    "OUR_ID": "REPLACE_ME",
-    "DEFAULT_ICON_PATH": "REPLACE_ME"
+    "S3_BUCKET_NAME": "202502-test-bucket",
+    "CDN_URL": "image.tankalizer.jp"
   },
   // secrets（wrangler secret put で登録、ローカルは .dev.vars）:
   //   GEMINI_API_KEY / NEWS_POST_API_KEY / S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY
+  //   NEWS_USER_ID / OUR_ID / DEFAULT_ICON_PATH（user_id 無検証の間は ID 類も非公開にする）
   "rules": [{ "type": "Text", "globs": ["**/*.txt"] }],
   "observability": { "enabled": true }
 }

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -13,9 +13,9 @@
       "migrations_dir": "migrations"
     }
   ],
-  // 旧 infra/lambda（EventBridge）のニュース自動投稿に相当。頻度は運用に合わせて調整
+  // 旧 infra/lambda（EventBridge）のニュース自動投稿に相当。カットオーバーまで一時停止中（再開時は ["0 */6 * * *"] 等に戻す）
   "triggers": {
-    "crons": ["0 */6 * * *"]
+    "crons": []
   },
   "vars": {
     "NODE_ENV": "production",

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -9,5 +9,9 @@
   },
   "observability": {
     "enabled": true
+  },
+  "vars": {
+    "AUTH_URL": "https://tankalizer.jp",
+    "BACKEND_URL": "https://api.tankalizer.jp/v2"
   }
 }


### PR DESCRIPTION
## Summary
- Fills in the real production values used for the Cloudflare cutover on 2026-08-02: the actual D1 database id, S3 bucket, and production domain vars for both Workers.
- The news cron is intentionally left disabled for now.

## Changes

### Backend (`backend/wrangler.jsonc`)
- Set the real D1 `database_id` (created via `wrangler d1 create tankalizer`) replacing the zero-UUID placeholder
- Set the actual S3 bucket name used by image uploads
- Removed the `NEWS_USER_ID` / `OUR_ID` / `DEFAULT_ICON_PATH` placeholder vars — they are now registered as Worker secrets instead, since the API currently trusts the client-supplied `user_id` and publishing these UUIDs in a public repo would allow posting as the news bot / developer accounts
- Paused the news cron (`"crons": []`) — kept off on purpose for now; re-enable by restoring `["0 */6 * * *"]` and redeploying

### Frontend (`frontend/wrangler.jsonc`)
- Added production runtime vars: `AUTH_URL=https://tankalizer.jp` and `BACKEND_URL=https://api.tankalizer.jp/v2`

## Notes
- These values are already live: both Workers are deployed with custom domains (`tankalizer.jp` / `api.tankalizer.jp`) and serving production traffic backed by D1
- `database_id` and the bucket name are identifiers, not credentials — safe in a public repo; all credentials and account UUIDs live in Worker secrets
- Follow-up (separate PR): add JWT verification on the backend so `user_id` is no longer trusted from the request body, after which the ID vars could return to plain config