### PR TITLE
feat: make the API Worker reachable only from the web Worker via a service binding

### DIFF
--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -4,6 +4,8 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-01",
   "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": false,
+  "preview_urls": false,
   "d1_databases": [
     {
       "binding": "DB",

--- a/frontend/src/app/(main)/post/[postId]/actions/fetchOnePost.ts
+++ b/frontend/src/app/(main)/post/[postId]/actions/fetchOnePost.ts
@@ -1,9 +1,8 @@
 // サーバアクション
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
 import { PostTypes } from '@/types/postTypes';
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 /**
  * 単体の投稿データを取得する非同期関数
@@ -22,7 +21,7 @@ export const fetchOnePost = async ({
   postId?: string;
 }): Promise<PostTypes | null> => {
   try {
-    const res = await fetch(`${backendUrl}/share`, {
+    const res = await backendFetch('/v2/share', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/profile/[userId]/actions/FollowunFollow.ts
+++ b/frontend/src/app/(main)/profile/[userId]/actions/FollowunFollow.ts
@@ -1,12 +1,11 @@
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
 import { FollowRequest } from '@/types/followunfollowTypes';
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 export const follow = async (data: FollowRequest) => {
   try {
-    const res = await fetch(`${backendUrl}/follow`, {
+    const res = await backendFetch('/v2/follow', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -28,7 +27,7 @@ export const follow = async (data: FollowRequest) => {
 
 export const unfollow = async (data: FollowRequest) => {
   try {
-    const res = await fetch(`${backendUrl}/unfollow`, {
+    const res = await backendFetch('/v2/unfollow', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/profile/[userId]/actions/fetchFollowings.ts
+++ b/frontend/src/app/(main)/profile/[userId]/actions/fetchFollowings.ts
@@ -1,9 +1,8 @@
 // サーバアクション
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
 import { ProfileTypes } from '@/types/profileTypes';
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 // response の型定義
 interface ProfileResponse {
@@ -42,7 +41,7 @@ export const fetchMutuals = async ({
   userId?: string;
 }): Promise<ProfileTypes[] | []> => {
   try {
-    const res = await fetch(`${backendUrl}/profile/mutual-following`, {
+    const res = await backendFetch('/v2/profile/mutual-following', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -102,7 +101,7 @@ export const fetchFollowing = async ({
   userId?: string;
 }): Promise<ProfileTypes[] | []> => {
   try {
-    const res = await fetch(`${backendUrl}/profile/following`, {
+    const res = await backendFetch('/v2/profile/following', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/profile/[userId]/actions/fetchProfile.ts
+++ b/frontend/src/app/(main)/profile/[userId]/actions/fetchProfile.ts
@@ -1,9 +1,8 @@
 // サーバアクション
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
 import { ProfileTypes } from '@/types/profileTypes';
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 /**
  * プロフィールを取得する非同期関数
@@ -22,7 +21,7 @@ const fetchProfile = async ({
   userId: string;
 }): Promise<ProfileTypes | undefined> => {
   try {
-    const res = await fetch(`${backendUrl}/profile`, {
+    const res = await backendFetch('/v2/profile', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/profile/[userId]/actions/updateProfile.ts
+++ b/frontend/src/app/(main)/profile/[userId]/actions/updateProfile.ts
@@ -1,8 +1,7 @@
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
 import { ProfileTypes } from '@/types/profileTypes';
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 /**
  * プロフィールを更新する非同期関数
@@ -35,7 +34,7 @@ const updateProfile = async ({
       formData.append('icon_image', imageData);
     }
 
-    const res = await fetch(`${backendUrl}/profile`, {
+    const res = await backendFetch('/v2/profile', {
       method: 'PUT',
       body: formData,
     });

--- a/frontend/src/app/(main)/timeline/actions/countMiyabi.ts
+++ b/frontend/src/app/(main)/timeline/actions/countMiyabi.ts
@@ -1,7 +1,7 @@
 // サーバアクション
 'use server';
 
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
+import { backendFetch } from '@/lib/backendFetch';
 
 /**
  * 雅を増やす非同期関数
@@ -13,7 +13,7 @@ const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
  */
 export const addMiyabi = async ({ userId, postId }: { userId: string; postId: string }) => {
   try {
-    const res = await fetch(`${backendUrl}/miyabi`, {
+    const res = await backendFetch('/v2/miyabi', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -43,7 +43,7 @@ export const addMiyabi = async ({ userId, postId }: { userId: string; postId: st
  */
 export const removeMiyabi = async ({ userId, postId }: { userId: string; postId: string }) => {
   try {
-    const res = await fetch(`${backendUrl}/miyabi`, {
+    const res = await backendFetch('/v2/miyabi', {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/timeline/actions/deletePost.ts
+++ b/frontend/src/app/(main)/timeline/actions/deletePost.ts
@@ -1,7 +1,7 @@
 // サーバアクション
 'use server';
 
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
+import { backendFetch } from '@/lib/backendFetch';
 
 /**
  * 投稿データを削除する非同期関数
@@ -20,7 +20,7 @@ const deletePost = async ({
   postId: string;
 }): Promise<boolean> => {
   try {
-    const res = await fetch(`${backendUrl}/post`, {
+    const res = await backendFetch('/v2/post', {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/timeline/actions/fetchPosts.ts
+++ b/frontend/src/app/(main)/timeline/actions/fetchPosts.ts
@@ -1,9 +1,8 @@
 // サーバアクション
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
 import { PostTypes } from '@/types/postTypes';
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 // response の型定義
 interface PostResponse {
@@ -44,7 +43,7 @@ export const fetchPosts = async ({
   userId?: string;
 }): Promise<PostTypes[] | []> => {
   try {
-    const res = await fetch(`${backendUrl}/timeline`, {
+    const res = await backendFetch('/v2/timeline', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -103,7 +102,7 @@ export const fetchRanking = async ({
   userId?: string;
 }): Promise<PostTypes[] | []> => {
   try {
-    const res = await fetch(`${backendUrl}/miyabiranking`, {
+    const res = await backendFetch('/v2/miyabiranking', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -163,7 +162,7 @@ export const fetchPostsForFollowing = async ({
   userId?: string;
 }): Promise<PostTypes[] | []> => {
   try {
-    const res = await fetch(`${backendUrl}/timeline/following`, {
+    const res = await backendFetch('/v2/timeline/following', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/(main)/timeline/actions/fetchUserId.ts
+++ b/frontend/src/app/(main)/timeline/actions/fetchUserId.ts
@@ -1,7 +1,7 @@
 // サーバアクション
 'use server';
 
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
+import { backendFetch } from '@/lib/backendFetch';
 
 /**
  * iconUrlからuserIdを取得する非同期関数
@@ -13,7 +13,7 @@ const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
  */
 const fetchUserId = async ({ iconUrl }: { iconUrl: string }): Promise<string> => {
   try {
-    const res = await fetch(`${backendUrl}/convert`, {
+    const res = await backendFetch('/v2/convert', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/yomu/CheckAuthUser.ts
+++ b/frontend/src/app/yomu/CheckAuthUser.ts
@@ -1,6 +1,6 @@
 'use server';
 
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
+import { backendFetch } from '@/lib/backendFetch';
 
 /**
  * 認可されたユーザーかどうかを確認する
@@ -11,7 +11,7 @@ export const checkAuthUser = async ({ iconUrl }: { iconUrl: string }): Promise<b
   try {
     console.log(iconUrl);
 
-    const res = await fetch(`${backendUrl}/isOurAccount`, {
+    const res = await backendFetch('/v2/isOurAccount', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/app/yomu/postActions.ts
+++ b/frontend/src/app/yomu/postActions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { backendFetch } from '@/lib/backendFetch';
+
 interface PostData {
   originalText: string;
   imageData?: File | null;
@@ -10,8 +12,6 @@ export interface PostResult {
   message: string;
   tanka: string[];
 }
-
-const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 /**
  * 短歌を投稿する
@@ -30,12 +30,12 @@ export const postYomu = async (data: PostData): Promise<PostResult> => {
 
     if (data.imageData) {
       formData.append('image', data.imageData);
-      res = await fetch(`${backendUrl}/post`, {
+      res = await backendFetch('/v2/post', {
         method: 'POST',
         body: formData,
       });
     } else {
-      res = await fetch(`${backendUrl}/post`, {
+      res = await backendFetch('/v2/post', {
         method: 'POST',
         body: formData,
       });

--- a/frontend/src/auth/config.ts
+++ b/frontend/src/auth/config.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import GitHub from 'next-auth/providers/github';
 import Google from 'next-auth/providers/google';
 import type { Provider } from 'next-auth/providers';
+import { backendFetch } from '@/lib/backendFetch';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
@@ -50,7 +51,6 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
   },
   callbacks: {
     jwt: async ({ token, user, trigger, account }) => {
-      // console.log(process.env.BACKEND_URL);
       if (trigger === 'signIn' && user && account) {
         try {
           const formData = new FormData();
@@ -67,7 +67,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
           formData.append('icon_url', user.image || `${baseUrl}/iconDefault.png`);
 
-          const res = await fetch(`${process.env.BACKEND_URL}/user`, {
+          const res = await backendFetch('/v2/user', {
             method: 'POST',
             body: formData,
           });

--- a/frontend/src/lib/backendFetch.ts
+++ b/frontend/src/lib/backendFetch.ts
@@ -1,0 +1,20 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
+type ApiBinding = {
+  fetch: typeof fetch;
+};
+
+const API_PREFIX = '/v2';
+
+export const backendFetch = (path: string, init?: RequestInit): Promise<Response> => {
+  const { env } = getCloudflareContext();
+  const api = (env as typeof env & { API?: ApiBinding }).API;
+
+  if (api) {
+    return api.fetch(new Request(`https://tankalizer-api.internal${path}`, init));
+  }
+
+  const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8080';
+  const fallbackPath = path.startsWith(API_PREFIX) ? path.slice(API_PREFIX.length) : path;
+  return fetch(`${backendUrl}${fallbackPath}`, init);
+};

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -10,6 +10,7 @@
   "observability": {
     "enabled": true
   },
+  "services": [{ "binding": "API", "service": "tankalizer-api" }],
   "vars": {
     "AUTH_URL": "https://tankalizer.jp",
     "BACKEND_URL": "https://api.tankalizer.jp/v2"


### PR DESCRIPTION
## Summary
- Replaces the public `api.tankalizer.jp` round-trip with a Cloudflare service binding, so the frontend calls the API Worker directly inside the Workers runtime.
- Combined with removing the API's public routes, the backend is no longer reachable from the internet — closing the door on direct API calls with a spoofed `user_id`.

## Changes

### Service binding plumbing
- `frontend/wrangler.jsonc`: add `services` binding `API` → `tankalizer-api`
- `frontend/src/lib/backendFetch.ts` (new): resolves the binding via `getCloudflareContext()` and dispatches requests through `env.API.fetch()` (the URL host is a dummy label; routing is done by the binding). Falls back to a plain `fetch(BACKEND_URL + path)` when no binding is available, so local `next dev` / docker-compose keep working

### Call-site migration
- All 12 Server Action files and the NextAuth `jwt` callback (`src/auth/config.ts`) now call `backendFetch('/v2/...')` instead of building URLs from `process.env.BACKEND_URL`; request methods, bodies, and headers are unchanged

### Locking down the API Worker
- `backend/wrangler.jsonc`: `workers_dev: false` and `preview_urls: false` (the `api.tankalizer.jp` custom domain was removed via the dashboard)

## Notes
- Traffic flow after this PR: browser → `tankalizer.jp` (web Worker) → service binding → API Worker → D1/S3. No DNS, TLS, or public hop between the two Workers
- Verified locally with two `wrangler dev` processes (binding `[connected]`, SSR post page renders data through the binding) and in production: `api.tankalizer.jp` now returns 530 while the site serves normally
- `BACKEND_URL` remains only as the fallback for non-Workers dev environments
- Deploy order matters for future reference: backend first, then frontend; JWT verification on the API is still a worthwhile follow-up even though the external path is gone